### PR TITLE
feat(i18n): support module label files and prefix core labels

### DIFF
--- a/clockwork/label.tsv
+++ b/clockwork/label.tsv
@@ -1,0 +1,14 @@
+key	de	en
+clockwork.title	Uhr	Clockwork
+clockwork.settings.timezone	Zeitzone	Timezone
+clockwork.settings.use_24h	24-Stunden-Format verwenden	Use 24-hour clock
+clockwork.settings.show_seconds	Sekunden anzeigen	Show seconds
+clockwork.settings.blink_colon	Doppelpunkt blinkt	Blink colon
+clockwork.settings.show_date	Datum anzeigen	Show date line
+clockwork.settings.date_format	Datumsformat	Date format
+clockwork.settings.update_ms	Aktualisierungsintervall (ms)	Update interval (ms)
+clockwork.settings.preview	Vorschau	Preview
+clockwork.error.invalid_tz_title	Ungültige Zeitzone	Invalid timezone
+clockwork.error.invalid_tz_msg	Bitte eine gültige Zeitzone eingeben.	Please enter a valid timezone.
+clockwork.info.saved	Einstellungen gespeichert	Settings saved
+clockwork.info.saved_msg	Deine Clockwork-Einstellungen wurden gespeichert.	Your Clockwork settings have been saved.

--- a/core/common/app_context.py
+++ b/core/common/app_context.py
@@ -22,8 +22,11 @@ from core.common.signature_api import SignatureAPI  # NEW
 root = Path(__file__).resolve().parents[2]
 labels_file = LABELS_TSV_PATH
 
-if labels_file.exists():
-    translations.load_file(labels_file)
+label_files = [labels_file]
+label_files += list(root.glob("**/label.tsv"))
+
+if label_files:
+    translations.load_files(label_files)
 else:
     translations.translations = {"de": {}, "en": {}}
 

--- a/core/config/gui/config_settings_view.py
+++ b/core/config/gui/config_settings_view.py
@@ -184,7 +184,7 @@ class ConfigSettingsTab(ttk.Frame):
     def _save_to_ini(self) -> None:
         ok, msg = self._validate()
         if not ok:
-            messagebox.showerror(T("Invalid configuration"), msg)
+            messagebox.showerror(T("core.invalid_configuration"), msg)
             logger.log("Config", "SaveFailed", username=_current_username(), message=msg)
             return
 
@@ -201,7 +201,7 @@ class ConfigSettingsTab(ttk.Frame):
 
         self._backup_to_db(silent=True)
         AppContext.update_language()                     # Sprache ggf. neu laden
-        messagebox.showinfo(T("Saved"), T("Configuration updated."))
+        messagebox.showinfo(T("core.saved"), T("core.configuration_updated"))
         logger.log("Config", "SaveToINI", username=_current_username())
 
     # -------- Backup-Helpers ---------- #

--- a/core/config/labels.tsv
+++ b/core/config/labels.tsv
@@ -1,70 +1,86 @@
 label	de	en
-add	Neu	Add
-admin	Administrator	Admin
-all_fields_required	Alle Felder sind erforderlich.	All fields are required.
-app_language	App-Sprache	App Language
-app_settings	Einstellungen	Settings
-cancel	Abbrechen	Cancel
-change_password	Passwort ändern	Change Password
-change_password_btn	Passwort ändern	Change Password
-current_password	Aktuelles Passwort	Current password
-current_password_wrong	Das aktuelle Passwort ist nicht korrekt.	Current password is incorrect.
-delete	Löschen	Delete
-department	Abteilung	Department
-documents	Dokumente	Documents
-edit	Bearbeiten	Edit
-email	E-Mail	Email
-error	Fehler	Error
-feature	Modul	Feature
-feature_add	Feature hinzufügen	Add Feature
-feature_already_exists	Modul existiert bereits	Feature already exists
-feature_cancel	Feature abbrechen	Cancel
-feature_created	Feature Erstellt	Feature Created
-feature_delete	Feature löschen	Delete Feature
-feature_deleted	Feature Gelöscht	Feature Deleted
-feature_description	Feature Beschreibung	Feature Description
-feature_description_required	Feature description ist erforderlich.	Feature description is required.
-feature_disabled	Feature Deaktiviert	Feature Disabled
-feature_edit	Feature bearbeiten	Edit Feature
-feature_enabled	Feature Aktiviert	Feature Enabled
-feature_list	Modul Liste	Feature List
-feature_name	Feature Name	Feature Name
-feature_name_required	Feature Name ist erforderlich.	Feature name is required.
-feature_not_found	Feature nicht gefunden	Feature not found
-feature_save	Feature speichern	Save Feature
-feature_updated	Feature Aktualisiert	Feature Updated
-full_name	Vollständiger Name	Full Name
-fullname	Vollständiger Name	Full Name
-job_title	Funktion	Job Title
-language	Sprache	Language
-language_changed	Sprache geändert	Language changed
-language_settings	Spracheinstellungen	Language Settings
-log_view	Logbuch	Log View
-login	Anmelden	Login
-logout	Abmelden	Logout
-main_dictionary	Dictionary ergänzen	Fill dictionary
-name_email_required	Name und E-Mail dürfen nicht leer sein.	Full name and email must not be empty.
-new_password	Neues Passwort	New password
-password	Passwort	Password
-password_changed	Passwort erfolgreich geändert.	Password changed successfully.
-passwords_no_match	Neue Passwörter stimmen nicht überein.	New passwords do not match.
-phone	Telefon	Phone
-profile_save_failed	Profiländerungen konnten nicht gespeichert werden.	Failed to save profile changes.
-profile_saved	Profiländerungen wurden gespeichert.	Profile changes have been saved.
-profile_tab	Profil & Konto	Profile & Account
-profile_title	Profil	Profile
-profile_updated	Profil aktualisiert	Profile Updated
-repeat_new_password	Neues Passwort wiederholen	Repeat new password
-restart_needed	Bitte starten Sie die Anwendung neu, damit die Sprachänderung wirksam wird.	Please restart the application for the language change to take full effect.
-role	Rolle	Role
-save	Speichern	Save
-save_profile	Profil speichern	Save Profile
-select_language	Sprache auswählen	Select Language
-set_language_btn	Sprache setzen	Set Language
-settings	Einstellungen	Settings
-sign_pdf	PDF signieren	Sign PDF
-success	Erfolg	Success
-update_failed	Aktualisierung fehlgeschlagen	Update Failed
-user_management	Benutzerverwaltung	User Management
-username	Benutzername	Username
-welcome	Willkommen	Welcome
+core.add	Neu	Add
+core.admin	Administrator	Admin
+core.all_fields_required	Alle Felder sind erforderlich.	All fields are required.
+core.app_language	App-Sprache	App Language
+core.app_settings	Einstellungen	Settings
+core.cancel	Abbrechen	Cancel
+core.change_password	Passwort ändern	Change Password
+core.change_password_btn	Passwort ändern	Change Password
+core.current_password	Aktuelles Passwort	Current password
+core.current_password_wrong	Das aktuelle Passwort ist nicht korrekt.	Current password is incorrect.
+core.delete	Löschen	Delete
+core.department	Abteilung	Department
+core.documents	Dokumente	Documents
+core.edit	Bearbeiten	Edit
+core.email	E-Mail	Email
+core.error	Fehler	Error
+core.feature	Modul	Feature
+core.feature_add	Feature hinzufügen	Add Feature
+core.feature_already_exists	Modul existiert bereits	Feature already exists
+core.feature_cancel	Feature abbrechen	Cancel
+core.feature_created	Feature Erstellt	Feature Created
+core.feature_delete	Feature löschen	Delete Feature
+core.feature_deleted	Feature Gelöscht	Feature Deleted
+core.feature_description	Feature Beschreibung	Feature Description
+core.feature_description_required	Feature description ist erforderlich.	Feature description is required.
+core.feature_disabled	Feature Deaktiviert	Feature Disabled
+core.feature_edit	Feature bearbeiten	Edit Feature
+core.feature_enabled	Feature Aktiviert	Feature Enabled
+core.feature_list	Modul Liste	Feature List
+core.feature_name	Feature Name	Feature Name
+core.feature_name_required	Feature Name ist erforderlich.	Feature name is required.
+core.feature_not_found	Feature nicht gefunden	Feature not found
+core.feature_save	Feature speichern	Save Feature
+core.feature_updated	Feature Aktualisiert	Feature Updated
+core.full_name	Vollständiger Name	Full Name
+core.fullname	Vollständiger Name	Full Name
+core.job_title	Funktion	Job Title
+core.language	Sprache	Language
+core.language_changed	Sprache geändert	Language changed
+core.language_settings	Spracheinstellungen	Language Settings
+core.log_view	Logbuch	Log View
+core.login	Anmelden	Login
+core.logout	Abmelden	Logout
+core.main_dictionary	Dictionary ergänzen	Fill dictionary
+core.name_email_required	Name und E-Mail dürfen nicht leer sein.	Full name and email must not be empty.
+core.new_password	Neues Passwort	New password
+core.password	Passwort	Password
+core.password_changed	Passwort erfolgreich geändert.	Password changed successfully.
+core.passwords_no_match	Neue Passwörter stimmen nicht überein.	New passwords do not match.
+core.phone	Telefon	Phone
+core.profile_save_failed	Profiländerungen konnten nicht gespeichert werden.	Failed to save profile changes.
+core.profile_saved	Profiländerungen wurden gespeichert.	Profile changes have been saved.
+core.profile_tab	Profil & Konto	Profile & Account
+core.profile_title	Profil	Profile
+core.profile_updated	Profil aktualisiert	Profile Updated
+core.repeat_new_password	Neues Passwort wiederholen	Repeat new password
+core.restart_needed	Bitte starten Sie die Anwendung neu, damit die Sprachänderung wirksam wird.	Please restart the application for the language change to take full effect.
+core.role	Rolle	Role
+core.save	Speichern	Save
+core.save_profile	Profil speichern	Save Profile
+core.select_language	Sprache auswählen	Select Language
+core.set_language_btn	Sprache setzen	Set Language
+core.settings	Einstellungen	Settings
+core.sign_pdf	PDF signieren	Sign PDF
+core.success	Erfolg	Success
+core.update_failed	Aktualisierung fehlgeschlagen	Update Failed
+core.user_management	Benutzerverwaltung	User Management
+core.username	Benutzername	Username
+core.welcome	Willkommen	Welcome
+core.config	Konfiguration	Config
+core.invalid_configuration	Ungültige Konfiguration	Invalid configuration
+core.saved	Gespeichert	Saved
+core.configuration_updated	Konfiguration aktualisiert.	Configuration updated.
+common.cancel	Abbrechen	Cancel
+common.clear	Leeren	Clear
+common.confirm	Bestätigen	Confirm
+common.done	Fertig	Done
+common.error	Fehler	Error
+common.import	Importieren	Import
+common.info	Info	Info
+common.question	Frage	Question
+common.reset	Zurücksetzen	Reset
+common.save	Speichern	Save
+common.saved	Gespeichert	Saved
+common.choose_file	Datei wählen	Choose file

--- a/core/i18n/fill_dictionary_view.py
+++ b/core/i18n/fill_dictionary_view.py
@@ -28,7 +28,7 @@ class FillDictionaryView(tk.Toplevel):
 
     def __init__(self, parent: tk.Widget):
         super().__init__(parent)
-        self.title(T("main_dictionary"))          # „Dict ergänzen“ / „Fill Dict“
+        self.title(T("core.main_dictionary"))          # „Dict ergänzen“ / „Fill Dict“
         self.geometry("900x500")
         self.transient(parent)
         self.grab_set()
@@ -51,8 +51,8 @@ class FillDictionaryView(tk.Toplevel):
 
         # Buttons
         btn_row = ttk.Frame(self); btn_row.pack(pady=6)
-        ttk.Button(btn_row, text=T("save"), command=self._save).pack(side="left", padx=5)
-        ttk.Button(btn_row, text=T("cancel"), command=self.destroy).pack(side="left", padx=5)
+        ttk.Button(btn_row, text=T("core.save"), command=self._save).pack(side="left", padx=5)
+        ttk.Button(btn_row, text=T("core.cancel"), command=self.destroy).pack(side="left", padx=5)
 
         self._load_data()
 

--- a/core/settings/gui/settings_view.py
+++ b/core/settings/gui/settings_view.py
@@ -58,5 +58,5 @@ class SettingsView(ttk.Frame):
 
         # Admin tabs
         if self._is_admin:
-            self._nb.add(ConfigSettingsTab(self._nb), text=T("config"))
+            self._nb.add(ConfigSettingsTab(self._nb), text=T("core.config"))
             self._nb.add(ModulesConfigTab(self._nb), text="Module Mgmt")

--- a/signature/label.tsv
+++ b/signature/label.tsv
@@ -1,4 +1,4 @@
-key	de-DE	en-US
+key	de	en
 core_signature.title	Unterschrift	PDF Signature
 core_signature.info	Wähle ein PDF und platziere Deine Unterschrift.	Select a PDF and place your signature.
 core_signature.pick	PDF auswählen	Choose PDF
@@ -43,11 +43,3 @@ core_signature.admin.always	immer nötig	always required
 core_signature.admin.never	nie nötig	never required
 core_signature.admin.user	nutzerabhängig	user-specific
 core_signature.user.require_pwd	Beim Signieren Passwort abfragen	Ask password on signing
-common.clear	Leeren	Clear
-common.import	Importieren	Import
-common.cancel	Abbrechen	Cancel
-common.save	Speichern	Save
-common.saved	Gespeichert	Saved
-common.choose_file	Datei wählen	Choose file
-common.done	Fertig	Done
-common.error	Fehler	Error

--- a/usermanagement/gui/user_settings_tab.py
+++ b/usermanagement/gui/user_settings_tab.py
@@ -34,28 +34,28 @@ class UserSettingsTab(Frame):
         self._build_language_section()
 
     def _build_profile_section(self):
-        Label(self, text=T("profile_title"), font=("Arial", 14, "bold")).pack(anchor="w", pady=(10,2))
+        Label(self, text=T("core.profile_title"), font=("Arial", 14, "bold")).pack(anchor="w", pady=(10,2))
         f = Frame(self)
         f.pack(fill="x", padx=5)
 
-        Label(f, text=T("username")).grid(row=0, column=0, sticky="w")
+        Label(f, text=T("core.username")).grid(row=0, column=0, sticky="w")
         Label(f, text=self._active_user.username).grid(row=0, column=1, sticky="w")
 
-        Label(f, text=T("fullname")).grid(row=1, column=0, sticky="w")
+        Label(f, text=T("core.fullname")).grid(row=1, column=0, sticky="w")
         fullname_entry = Entry(f, textvariable=self.fullname_var)
         fullname_entry.grid(row=1, column=1, sticky="ew")
 
-        Label(f, text=T("email")).grid(row=2, column=0, sticky="w")
+        Label(f, text=T("core.email")).grid(row=2, column=0, sticky="w")
         email_entry = Entry(f, textvariable=self.email_var)
         email_entry.grid(row=2, column=1, sticky="ew")
 
-        Button(f, text=T("save_profile"), command=self._save_profile).grid(row=3, column=1, sticky="e", pady=(8,2))
+        Button(f, text=T("core.save_profile"), command=self._save_profile).grid(row=3, column=1, sticky="e", pady=(8,2))
 
     def _save_profile(self):
         name = self.fullname_var.get().strip()
         email = self.email_var.get().strip()
         if not name or not email:
-            messagebox.showerror(T("error"), T("name_email_required"))
+            messagebox.showerror(T("core.error"), T("core.name_email_required"))
             return
         updated = self.user_manager.update_user(
             username=self._active_user.username,
@@ -64,26 +64,26 @@ class UserSettingsTab(Frame):
             full_name=name
         )
         if updated:
-            messagebox.showinfo(T("profile_updated"), T("profile_saved"))
+            messagebox.showinfo(T("core.profile_updated"), T("core.profile_saved"))
             self._active_user.full_name = name
             self._active_user.email = email
         else:
-            messagebox.showerror(T("update_failed"), T("profile_save_failed"))
+            messagebox.showerror(T("core.update_failed"), T("core.profile_save_failed"))
 
     def _build_password_section(self):
-        Label(self, text=T("change_password"), font=("Arial", 14, "bold")).pack(anchor="w", pady=(18,2))
+        Label(self, text=T("core.change_password"), font=("Arial", 14, "bold")).pack(anchor="w", pady=(18,2))
         f = Frame(self)
         f.pack(fill="x", padx=5)
 
-        Label(f, text=T("current_password")).grid(row=0, column=0, sticky="w")
+        Label(f, text=T("core.current_password")).grid(row=0, column=0, sticky="w")
         old_pw_entry = Entry(f, show="*")
         old_pw_entry.grid(row=0, column=1, sticky="ew")
 
-        Label(f, text=T("new_password")).grid(row=1, column=0, sticky="w")
+        Label(f, text=T("core.new_password")).grid(row=1, column=0, sticky="w")
         new_pw_entry = Entry(f, show="*")
         new_pw_entry.grid(row=1, column=1, sticky="ew")
 
-        Label(f, text=T("repeat_new_password")).grid(row=2, column=0, sticky="w")
+        Label(f, text=T("core.repeat_new_password")).grid(row=2, column=0, sticky="w")
         repeat_pw_entry = Entry(f, show="*")
         repeat_pw_entry.grid(row=2, column=1, sticky="ew")
 
@@ -92,27 +92,27 @@ class UserSettingsTab(Frame):
             new_pw = new_pw_entry.get()
             repeat_pw = repeat_pw_entry.get()
             if not old_pw or not new_pw or not repeat_pw:
-                messagebox.showerror(T("error"), T("all_fields_required"))
+                messagebox.showerror(T("core.error"), T("core.all_fields_required"))
                 return
             if new_pw != repeat_pw:
-                messagebox.showerror(T("error"), T("passwords_no_match"))
+                messagebox.showerror(T("core.error"), T("core.passwords_no_match"))
                 return
             if self.user_manager.change_password(self._active_user.username, old_pw, new_pw):
-                messagebox.showinfo(T("success"), T("password_changed"))
+                messagebox.showinfo(T("core.success"), T("core.password_changed"))
                 old_pw_entry.delete(0, "end")
                 new_pw_entry.delete(0, "end")
                 repeat_pw_entry.delete(0, "end")
             else:
-                messagebox.showerror(T("error"), T("current_password_wrong"))
+                messagebox.showerror(T("core.error"), T("core.current_password_wrong"))
 
-        Button(f, text=T("change_password_btn"), command=do_change_pw).grid(row=3, column=1, sticky="e", pady=(8,2))
+        Button(f, text=T("core.change_password_btn"), command=do_change_pw).grid(row=3, column=1, sticky="e", pady=(8,2))
 
     def _build_language_section(self):
-        Label(self, text=T("language_settings"), font=("Arial", 14, "bold")).pack(anchor="w", pady=(18,2))
+        Label(self, text=T("core.language_settings"), font=("Arial", 14, "bold")).pack(anchor="w", pady=(18,2))
         f = Frame(self)
         f.pack(fill="x", padx=5)
 
-        Label(f, text=T("language")).grid(row=0, column=0, sticky="w")
+        Label(f, text=T("core.language")).grid(row=0, column=0, sticky="w")
         from core.i18n import locale
         languages = locale.get_available_languages()
         lang_combo = ttk.Combobox(f, textvariable=self.language_var, values=languages, state="readonly")
@@ -121,6 +121,6 @@ class UserSettingsTab(Frame):
         def do_set_language():
             sel = self.language_var.get()
             locale.set_language(sel)
-            messagebox.showinfo(T("language_changed"), T("restart_needed"))
+            messagebox.showinfo(T("core.language_changed"), T("core.restart_needed"))
 
-        Button(f, text=T("set_language_btn"), command=do_set_language).grid(row=1, column=1, sticky="e", pady=(8,2))
+        Button(f, text=T("core.set_language_btn"), command=do_set_language).grid(row=1, column=1, sticky="e", pady=(8,2))

--- a/usermanagement/gui/user_view.py
+++ b/usermanagement/gui/user_view.py
@@ -65,17 +65,17 @@ class UserManagementView(Frame):
     # ------------------------------------------------------------------ #
     def _build_login_view(self):
         self._clear()
-        Label(self, text=T("login"), font=("Arial", 16)).pack(pady=10)
+        Label(self, text=T("core.login"), font=("Arial", 16)).pack(pady=10)
 
         self.username_entry = Entry(self)
         self.username_entry.pack(pady=5)
-        self.username_entry.insert(0, T("username"))
+        self.username_entry.insert(0, T("core.username"))
 
         self.password_entry = Entry(self, show="*")
         self.password_entry.pack(pady=5)
-        self.password_entry.insert(0, T("password"))
+        self.password_entry.insert(0, T("core.password"))
 
-        Button(self, text=T("login"), command=self._handle_login).pack(pady=10)
+        Button(self, text=T("core.login"), command=self._handle_login).pack(pady=10)
 
         # Erst-Admin anlegen, wenn DB leer
         if not self.user_manager.get_all_users():
@@ -89,17 +89,17 @@ class UserManagementView(Frame):
 
         if user:
             self.active_user = user
-            self.set_status(f"{T('login')} {T('success')}")
+            self.set_status(f"{T('core.login')} {T('core.success')}")
             if self.on_login_success:
                 self.on_login_success()
             self._build_main_view()
         else:
-            self.set_status(T("current_password_wrong"))
-            messagebox.showerror(T("error"), T("current_password_wrong"))
+            self.set_status(T("core.current_password_wrong"))
+            messagebox.showerror(T("core.error"), T("core.current_password_wrong"))
 
     def _handle_logout(self):
         self.user_manager.logout()
-        self.set_status(T("logout"))
+        self.set_status(T("core.logout"))
         if self.on_logout:
             self.on_logout()
         self.active_user = None
@@ -118,26 +118,26 @@ class UserManagementView(Frame):
 
         # Profil
         pf = Frame(nb); self._build_profile_tab(pf)
-        nb.add(pf, text=T("profile_tab"))
+        nb.add(pf, text=T("core.profile_tab"))
 
         # Passwort
         pw = Frame(nb); self._build_password_tab(pw)
-        nb.add(pw, text=T("change_password"))
+        nb.add(pw, text=T("core.change_password"))
 
         # Platzhalter
-        sig = Frame(nb); Label(sig, text=T("sign_pdf")).pack()
-        nb.add(sig, text=T("sign_pdf"))
+        sig = Frame(nb); Label(sig, text=T("core.sign_pdf")).pack()
+        nb.add(sig, text=T("core.sign_pdf"))
 
         # Admin
         if self.active_user.role == UserRole.ADMIN:
             adm = Frame(nb); self._build_admin_panel(adm)
-            nb.add(adm, text=T("user_management"))
+            nb.add(adm, text=T("core.user_management"))
 
     # ------------------------------------------------------------------ #
     # Profil-Tab                                                         #
     # ------------------------------------------------------------------ #
     def _build_profile_tab(self, frame: Frame):
-        Label(frame, text=T("profile_title"), font=("Arial", 14, "bold")).pack(pady=8)
+        Label(frame, text=T("core.profile_title"), font=("Arial", 14, "bold")).pack(pady=8)
         tbl = Frame(frame); tbl.pack(padx=10, pady=8)
 
         self.profile_entries: Dict[str, tk.StringVar] = {}
@@ -149,12 +149,12 @@ class UserManagementView(Frame):
             self.profile_entries[fld] = var
         tbl.grid_columnconfigure(1, weight=1)
 
-        Button(frame, text=T("save_profile"), command=self._save_profile).pack(pady=10)
+        Button(frame, text=T("core.save_profile"), command=self._save_profile).pack(pady=10)
 
     def _save_profile(self):
         updates = {f: v.get() for f, v in self.profile_entries.items()}
         ok = self.user_manager.update_user_profile(self.active_user.username, updates)
-        self.set_status(T("profile_saved") if ok else T("profile_save_failed"))
+        self.set_status(T("core.profile_saved") if ok else T("core.profile_save_failed"))
         if ok:
             for f, v in updates.items():
                 setattr(self.active_user, f, v)
@@ -163,44 +163,44 @@ class UserManagementView(Frame):
     # Passwort-Tab                                                       #
     # ------------------------------------------------------------------ #
     def _build_password_tab(self, frame: Frame):
-        Label(frame, text=T("change_password"), font=("Arial", 14, "bold")).pack(pady=10)
+        Label(frame, text=T("core.change_password"), font=("Arial", 14, "bold")).pack(pady=10)
         form = Frame(frame); form.pack(pady=10)
 
-        Label(form, text=T("current_password")).grid(row=0, column=0, sticky="w")
+        Label(form, text=T("core.current_password")).grid(row=0, column=0, sticky="w")
         old_e = Entry(form, show="*"); old_e.grid(row=0, column=1, pady=2)
 
-        Label(form, text=T("new_password")).grid(row=1, column=0, sticky="w")
+        Label(form, text=T("core.new_password")).grid(row=1, column=0, sticky="w")
         new_e = Entry(form, show="*"); new_e.grid(row=1, column=1, pady=2)
 
-        Label(form, text=T("repeat_new_password")).grid(row=2, column=0, sticky="w")
+        Label(form, text=T("core.repeat_new_password")).grid(row=2, column=0, sticky="w")
         rep_e = Entry(form, show="*"); rep_e.grid(row=2, column=1, pady=2)
 
         def do_change():
             old, new, rep = old_e.get(), new_e.get(), rep_e.get()
             if not all((old, new, rep)):
-                self.set_status(T("all_fields_required"))
-                messagebox.showerror(T("error"), T("all_fields_required"))
+                self.set_status(T("core.all_fields_required"))
+                messagebox.showerror(T("core.error"), T("core.all_fields_required"))
                 return
             if new != rep:
-                self.set_status(T("passwords_no_match"))
-                messagebox.showerror(T("error"), T("passwords_no_match"))
+                self.set_status(T("core.passwords_no_match"))
+                messagebox.showerror(T("core.error"), T("core.passwords_no_match"))
                 return
             ok = self.user_manager.change_password(self.active_user.username, old, new)
             if ok:
-                self.set_status(T("password_changed"))
-                messagebox.showinfo(T("success"), T("password_changed"))
+                self.set_status(T("core.password_changed"))
+                messagebox.showinfo(T("core.success"), T("core.password_changed"))
             else:
-                self.set_status(T("current_password_wrong"))
-                messagebox.showerror(T("error"), T("current_password_wrong"))
+                self.set_status(T("core.current_password_wrong"))
+                messagebox.showerror(T("core.error"), T("core.current_password_wrong"))
             old_e.delete(0, "end"); new_e.delete(0, "end"); rep_e.delete(0, "end")
 
-        Button(frame, text=T("change_password_btn"), command=do_change).pack(pady=10)
+        Button(frame, text=T("core.change_password_btn"), command=do_change).pack(pady=10)
 
     # ------------------------------------------------------------------ #
     # Admin-Panel                                                        #
     # ------------------------------------------------------------------ #
     def _build_admin_panel(self, frame: Frame):
-        Label(frame, text=T("user_management"), font=("Arial", 14, "bold")).pack(pady=(10, 4))
+        Label(frame, text=T("core.user_management"), font=("Arial", 14, "bold")).pack(pady=(10, 4))
 
         cols = ["username", "email", "role", "full_name", "phone", "department", "job_title"]
         tree = ttk.Treeview(frame, columns=cols, show="headings")
@@ -211,9 +211,9 @@ class UserManagementView(Frame):
         self.admin_user_tree = tree
 
         btn_row = Frame(frame); btn_row.pack(pady=4)
-        Button(btn_row, text=T("edit"), command=self._popup_edit_user).pack(side="left", padx=5)
-        Button(btn_row, text=T("delete"), command=self._delete_selected_user).pack(side="left", padx=5)
-        Button(btn_row, text=T("add"), command=self._popup_create_user).pack(side="left", padx=5)
+        Button(btn_row, text=T("core.edit"), command=self._popup_edit_user).pack(side="left", padx=5)
+        Button(btn_row, text=T("core.delete"), command=self._delete_selected_user).pack(side="left", padx=5)
+        Button(btn_row, text=T("core.add"), command=self._popup_create_user).pack(side="left", padx=5)
 
         self._refresh_user_list()
 
@@ -234,8 +234,8 @@ class UserManagementView(Frame):
     def _popup_edit_user(self):
         sel = self.admin_user_tree.focus()
         if not sel:
-            self.set_status(T("update_failed"))
-            messagebox.showerror(T("error"), T("update_failed"))
+            self.set_status(T("core.update_failed"))
+            messagebox.showerror(T("core.error"), T("core.update_failed"))
             return
 
         username = self.admin_user_tree.item(sel)["values"][0]
@@ -263,14 +263,14 @@ class UserManagementView(Frame):
             upd = {f: ents[f].get() for f in fields}
             ok = self.user_manager.update_user_profile(username, upd)
             self._refresh_user_list(); pop.destroy()
-            self.set_status(T("profile_saved") if ok else T("profile_save_failed"))
+            self.set_status(T("core.profile_saved") if ok else T("core.profile_save_failed"))
 
-        Button(pop, text=T("save"), command=save) \
+        Button(pop, text=T("core.save"), command=save) \
             .grid(row=len(fields), column=0, columnspan=2, pady=10)
     # ---------- Popup: CREATE USER ------------------------------------ #
     def _popup_create_user(self):
         pop = tk.Toplevel(self);
-        pop.title(T("user_management"))
+        pop.title(T("core.user_management"))
         pop.grab_set();
         pop.resizable(False, False)
 
@@ -299,32 +299,32 @@ class UserManagementView(Frame):
                     for f in fields}
 
             if not data["username"] or not data["password"] or not data["email"]:
-                self.set_status(T("all_fields_required"))
-                messagebox.showerror(T("error"), T("all_fields_required"))
+                self.set_status(T("core.all_fields_required"))
+                messagebox.showerror(T("core.error"), T("core.all_fields_required"))
                 return
 
             ok = self.user_manager.register_full(data)
             self._refresh_user_list();
             pop.destroy()
-            self.set_status(T("profile_saved") if ok else T("profile_save_failed"))
+            self.set_status(T("core.profile_saved") if ok else T("core.profile_save_failed"))
 
-        Button(pop, text=T("save"), command=save) \
+        Button(pop, text=T("core.save"), command=save) \
             .grid(row=len(fields), column=0, columnspan=2, pady=10)
 
     def _delete_selected_user(self):
         sel = self.admin_user_tree.focus()
         if not sel:
-            self.set_status(T("update_failed"))
-            messagebox.showerror(T("error"), T("update_failed"))
+            self.set_status(T("core.update_failed"))
+            messagebox.showerror(T("core.error"), T("core.update_failed"))
             return
 
         username = self.admin_user_tree.item(sel)["values"][0]
         if username == self.active_user.username:
             self.set_status("Cannot delete your own account.")
-            messagebox.showerror(T("error"), "Cannot delete your own account.")
+            messagebox.showerror(T("core.error"), "Cannot delete your own account.")
             return
 
-        if messagebox.askyesno(T("delete"), f"{T('delete')} {username}?"):
+        if messagebox.askyesno(T("core.delete"), f"{T('core.delete')} {username}?"):
             ok = self.user_manager.delete_user(username)
             self._refresh_user_list()
-            self.set_status(T("profile_saved") if ok else T("profile_save_failed"))
+            self.set_status(T("core.profile_saved") if ok else T("core.profile_save_failed"))


### PR DESCRIPTION
## Summary
- load translations from multiple module `label.tsv` files
- prefix core translations with `core.` and centralize common labels
- add Clockwork module translations

## Testing
- `python -m py_compile core/i18n/translation_manager.py core/common/app_context.py core/config/gui/config_settings_view.py core/i18n/fill_dictionary_view.py core/settings/gui/settings_view.py usermanagement/gui/user_settings_tab.py usermanagement/gui/user_view.py`
- `python - <<'PY'
from core.i18n.translation_manager import TranslationManager
from pathlib import Path
files=[Path('core/config/labels.tsv'), Path('signature/label.tsv'), Path('clockwork/label.tsv')]
tm=TranslationManager()
tm.load_files(files)
print('core.add:', tm.t('core.add','de'))
print('common.save:', tm.t('common.save','de'))
print('clockwork.title:', tm.t('clockwork.title','de'))
PY`
- `python -m py_compile $(git ls-files '*.py')` *(fails: `EmptyFeature/gui/modul_settings_view.py: SyntaxError: invalid syntax`)*

------
https://chatgpt.com/codex/tasks/task_e_68af87d5cd40832b9816ad4ac07da119