### PR TITLE
feat: add layered typed config service

### DIFF
--- a/core/config/config_loader.py
+++ b/core/config/config_loader.py
@@ -1,161 +1,55 @@
 """
-core/config/config_loader.py
-============================
+Backward-compatible wrapper delegating to :mod:`config_service`.
 
-Zentraler Konfigurations-Loader (Singleton).
-
-• Sucht das Projekt-Root dynamisch (Verzeichnis mit »core«-Ordner).
-• Legt *config.ini* bei Bedarf automatisch unter  <root>/core/config  an.
-• Liefert Pfade zu qm_tool.db & logs.db (liegen unter  <root>/databases).
-• Stellt Getter für App-Name & Version bereit (Read-Only).
-• Keine Schreib-API – die INI wird bewusst manuell gepflegt.
-
-Diese Datei hält sich an unsere Projekt-Konventionen:
-    – Single Responsibility
-    – Klare Docstrings + Kommentare
-    – Keine externen Abhängigkeiten außer stdlib
+Existing callers can keep using :class:`ConfigLoader` while the new
+:class:`ConfigService` provides layered, typed configuration handling.
 """
-
 from __future__ import annotations
 
-import configparser
 from pathlib import Path
 from threading import RLock
 
-
-# --------------------------------------------------------------------------- #
-#  Root- und Pfadermittlung
-# --------------------------------------------------------------------------- #
-def _find_project_root() -> Path:
-    """
-    Geht von diesem File nach oben, bis ein Ordner *core* gefunden wird.
-    Das ist unser Projekt-Root.
-    """
-    here = Path(__file__).resolve()
-    for parent in here.parents:
-        if (parent / "core").is_dir():
-            return parent
-    # Fallback: ein Verzeichnis oberhalb (sollte quasi nie passieren)
-    return here.parent
+from .config_service import ConfigService, config_service
 
 
-PROJECT_ROOT = _find_project_root()                        # <root>
-CONFIG_DIR = PROJECT_ROOT / "core" / "config"              # <root>/core/config
-INI_PATH = CONFIG_DIR / "config.ini"                       # <root>/core/config/config.ini
-DATABASE_DIR = PROJECT_ROOT / "databases"                  # <root>/databases
-
-
-# --------------------------------------------------------------------------- #
-#  Default-Inhalte für eine neu erzeugte config.ini
-# --------------------------------------------------------------------------- #
-_DEFAULT_INI_CONTENT = {
-    "Database": {
-        "qm_tool": str((DATABASE_DIR / "qm-tool.db").as_posix()),
-        "logging": str((DATABASE_DIR / "logs.db").as_posix()),
-    },
-    "General": {
-        "app_name": "",
-        "version": "",
-    },
-    "Files": {
-        "modules_json": str((PROJECT_ROOT / "core" / "config" / "modules.json").as_posix()),
-        "labels_tsv": str((PROJECT_ROOT / "core" / "config" / "labels.tsv").as_posix()),
-    },
-}
-
-
-# --------------------------------------------------------------------------- #
-#  Interne Helfer
-# --------------------------------------------------------------------------- #
-def _ensure_ini_exists() -> None:
-    """
-    Stellt sicher, dass CONFIG_DIR & config.ini vorhanden sind.
-    Wird automatisch beim ersten Zugriff auf den Singleton aufgerufen.
-    """
-    CONFIG_DIR.mkdir(parents=True, exist_ok=True)
-
-    if not INI_PATH.exists():
-        parser = configparser.ConfigParser()
-        parser.read_dict(_DEFAULT_INI_CONTENT)
-        with INI_PATH.open("w", encoding="utf-8") as f:
-            parser.write(f)
-
-
-# --------------------------------------------------------------------------- #
-#  ConfigLoader-Singleton
-# --------------------------------------------------------------------------- #
 class ConfigLoader:
-    """Thread-sicherer Singleton zum Laden der config.ini."""
+    """Thin wrapper around :class:`ConfigService` (legacy API)."""
 
     _instance: "ConfigLoader | None" = None
     _lock = RLock()
 
-    # ------------------------------------------------------------------- #
-    #  Erzeugung
-    # ------------------------------------------------------------------- #
-    def __new__(cls) -> "ConfigLoader":
+    def __new__(cls) -> "ConfigLoader":  # noqa: D401
         with cls._lock:
             if cls._instance is None:
-                _ensure_ini_exists()
                 cls._instance = super().__new__(cls)
-                cls._instance._load_config()
+                cls._instance._service = config_service
             return cls._instance
 
-    # ------------------------------------------------------------------- #
-    #  Init-Helpers
-    # ------------------------------------------------------------------- #
-    def _load_config(self) -> None:
-        """Liest die INI in einen ConfigParser ein."""
-        self._config = configparser.ConfigParser()
-        self._config.read(INI_PATH, encoding="utf-8")
-
-    # ------------------------------------------------------------------- #
-    #  Öffentliche Getter
-    # ------------------------------------------------------------------- #
+    # ------------------------------------------------------------------ #
+    #  Delegated getters
+    # ------------------------------------------------------------------ #
     def get_qm_db_path(self) -> Path:
-        """Pfad zur Haupt­datenbank (qm_tool.db)."""
-        return Path(
-            self._config.get(
-                "Database", "qm_tool", fallback=_DEFAULT_INI_CONTENT["Database"]["qm_tool"]
-            )
-        ).expanduser()
+        return self._service.database.qm_tool
 
     def get_logging_db_path(self) -> Path:
-        """Pfad zur Logging-Datenbank (logs.db)."""
-        return Path(
-            self._config.get(
-                "Database", "logging", fallback=_DEFAULT_INI_CONTENT["Database"]["logging"]
-            )
-        ).expanduser()
+        return self._service.database.logging
 
     def get_app_name(self) -> str:
-        """Anwendungs-Name (optional, leer möglich)."""
-        return self._config.get(
-            "General", "app_name", fallback=_DEFAULT_INI_CONTENT["General"]["app_name"]
-        )
+        return self._service.general.app_name
 
     def get_version(self) -> str:
-        """Versions­nummer (optional, leer möglich)."""
-        return self._config.get(
-            "General", "version", fallback=_DEFAULT_INI_CONTENT["General"]["version"]
-        )
+        return self._service.general.version
 
     def get_modules_json_path(self) -> Path:
-        return Path(self._config.get(
-            "Files", "modules_json", fallback=_DEFAULT_INI_CONTENT["Files"]["modules_json"]
-        )).expanduser()
+        return self._service.files.modules_json
 
     def get_labels_tsv_path(self) -> Path:
-        return Path(self._config.get(
-            "Files", "labels_tsv", fallback=_DEFAULT_INI_CONTENT["Files"]["labels_tsv"]
-        )).expanduser()
+        return self._service.files.labels_tsv
 
 
-# --------------------------------------------------------------------------- #
-#  Globale Instanz für bequemen Zugriff
-# --------------------------------------------------------------------------- #
+# Global convenience accessors
 config_loader: ConfigLoader = ConfigLoader()  # pylint: disable=invalid-name
 QM_DB_PATH: Path = config_loader.get_qm_db_path()
 LOG_DB_PATH: Path = config_loader.get_logging_db_path()
 MODULES_JSON_PATH = config_loader.get_modules_json_path()
-LABELS_TSV_PATH   = config_loader.get_labels_tsv_path()
+LABELS_TSV_PATH = config_loader.get_labels_tsv_path()

--- a/core/config/config_service.py
+++ b/core/config/config_service.py
@@ -1,0 +1,238 @@
+"""Typed, layered configuration loader with precedence handling."""
+from __future__ import annotations
+
+import os
+import configparser
+import shutil
+from dataclasses import dataclass, fields
+from pathlib import Path
+from threading import RLock
+from typing import Any, Callable, Dict, Tuple
+
+# --------------------------------------------------------------------------- #
+#  Paths & default definitions
+# --------------------------------------------------------------------------- #
+
+def _find_project_root() -> Path:
+    here = Path(__file__).resolve()
+    for parent in here.parents:
+        if (parent / "core").is_dir():
+            return parent
+    return here.parent
+
+PROJECT_ROOT = _find_project_root()
+CONFIG_DIR = PROJECT_ROOT / "core" / "config"
+DEFAULTS_INI = CONFIG_DIR / "defaults.ini"
+MACHINE_INI = CONFIG_DIR / "config.ini"
+
+
+_DEFAULTS: Dict[str, Dict[str, Any]] = {
+    "Database": {
+        "qm_tool": (PROJECT_ROOT / "databases" / "qm-tool.db").as_posix(),
+        "logging": (PROJECT_ROOT / "databases" / "logs.db").as_posix(),
+    },
+    "Files": {
+        "modules_json": (PROJECT_ROOT / "core" / "config" / "modules.json").as_posix(),
+        "labels_tsv": (PROJECT_ROOT / "core" / "config" / "labels.tsv").as_posix(),
+    },
+    "General": {
+        "app_name": "",
+        "version": "",
+        "debug_db_paths": "false",
+    },
+    "Features": {
+        "enable_document_signer": "false",
+        "enable_workflow_manager": "false",
+    },
+}
+
+
+# --------------------------------------------------------------------------- #
+#  Datamodels
+# --------------------------------------------------------------------------- #
+
+@dataclass
+class DatabaseConfig:
+    qm_tool: Path
+    logging: Path
+
+
+@dataclass
+class FilesConfig:
+    modules_json: Path
+    labels_tsv: Path
+
+
+@dataclass
+class GeneralConfig:
+    app_name: str = ""
+    version: str = ""
+    debug_db_paths: bool = False
+
+
+@dataclass
+class FeaturesConfig:
+    enable_document_signer: bool = False
+    enable_workflow_manager: bool = False
+
+
+@dataclass
+class AppConfig:
+    database: DatabaseConfig
+    files: FilesConfig
+    general: GeneralConfig
+    features: FeaturesConfig
+
+
+# --------------------------------------------------------------------------- #
+#  Helpers
+# --------------------------------------------------------------------------- #
+
+_DEF_LOCK = RLock()
+
+
+def _ensure_machine_config() -> None:
+    """Ensure config directory and machine config exist."""
+    CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+    if not MACHINE_INI.exists():
+        if DEFAULTS_INI.exists():
+            shutil.copy(DEFAULTS_INI, MACHINE_INI)
+        else:
+            parser = configparser.ConfigParser()
+            parser.read_dict(_DEFAULTS)
+            with MACHINE_INI.open("w", encoding="utf-8") as fh:
+                parser.write(fh)
+
+
+def _cp_to_dict(cp: configparser.ConfigParser) -> Dict[str, Dict[str, Any]]:
+    data: Dict[str, Dict[str, Any]] = {}
+    for section in cp.sections():
+        data[section] = {k: v for k, v in cp.items(section)}
+    return data
+
+
+def _apply(target: Dict[str, Dict[str, Any]], source: Dict[str, Dict[str, Any]],
+           layer: str, origin: str,
+           sources: Dict[Tuple[str, str], Dict[str, str]]) -> None:
+    for section, items in source.items():
+        sec = target.setdefault(section, {})
+        for key, value in items.items():
+            sec[key] = value
+            sources[(section, key)] = {"layer": layer, "source": origin}
+
+
+def _cast(value: Any, typ: type) -> Any:
+    if typ is Path:
+        return Path(str(value)).expanduser()
+    if typ is bool:
+        if isinstance(value, bool):
+            return value
+        return str(value).strip().lower() in {"1", "true", "yes", "on"}
+    if typ is int:
+        return int(value)
+    if typ is float:
+        return float(value)
+    return typ(value)
+
+
+def _build_dataclass(cls: type, data: Dict[str, Any]) -> Any:
+    kwargs = {}
+    for field in fields(cls):
+        val = data.get(field.name, field.default)
+        kwargs[field.name] = _cast(val, field.type)
+    return cls(**kwargs)
+
+
+def _env_overlays() -> Dict[str, Dict[str, Any]]:
+    prefix = "QMTOOL_"
+    result: Dict[str, Dict[str, Any]] = {}
+    for env_key, value in os.environ.items():
+        if not env_key.startswith(prefix):
+            continue
+        remainder = env_key[len(prefix):]
+        parts = remainder.split("__", 1)
+        if len(parts) != 2:
+            continue
+        section, key = parts
+        section = section.title()
+        key = key.lower()
+        result.setdefault(section, {})[key] = value
+    return result
+
+
+def _user_config_path() -> Path:
+    if os.name == "nt":
+        appdata = os.environ.get("APPDATA") or (Path.home() / "AppData" / "Roaming")
+        return Path(appdata) / "QMTool" / "config.ini"
+    return Path(os.environ.get("XDG_CONFIG_HOME", Path.home() / ".config")) / "qmtool" / "config.ini"
+
+
+# --------------------------------------------------------------------------- #
+#  ConfigService
+# --------------------------------------------------------------------------- #
+
+
+class ConfigService:
+    """Facade merging layered configuration with type safety."""
+
+    def __init__(self) -> None:
+        self._lock = RLock()
+        _ensure_machine_config()
+        self.reload()
+
+    # ------------------------------------------------------------------ #
+    def reload(self) -> None:
+        with self._lock:
+            merged: Dict[str, Dict[str, Any]] = {}
+            sources: Dict[Tuple[str, str], Dict[str, str]] = {}
+
+            # Layer 0: embedded defaults
+            _apply(merged, _DEFAULTS, "code", "embedded", sources)
+
+            # Layer 1: defaults.ini
+            if DEFAULTS_INI.exists():
+                cp = configparser.ConfigParser()
+                cp.read(DEFAULTS_INI, encoding="utf-8")
+                _apply(merged, _cp_to_dict(cp), "defaults.ini", str(DEFAULTS_INI), sources)
+
+            # Layer 2: environment variables
+            env = _env_overlays()
+            _apply(merged, env, "env", "os.environ", sources)
+
+            # Layer 3: machine config
+            if MACHINE_INI.exists():
+                cp = configparser.ConfigParser()
+                cp.read(MACHINE_INI, encoding="utf-8")
+                _apply(merged, _cp_to_dict(cp), "machine", str(MACHINE_INI), sources)
+
+            # Layer 4: user overrides
+            user_ini = _user_config_path()
+            if user_ini.exists():
+                cp = configparser.ConfigParser()
+                cp.read(user_ini, encoding="utf-8")
+                _apply(merged, _cp_to_dict(cp), "user", str(user_ini), sources)
+
+            self._merged = merged
+            self._sources = sources
+
+            self.database = _build_dataclass(DatabaseConfig, merged.get("Database", {}))
+            self.files = _build_dataclass(FilesConfig, merged.get("Files", {}))
+            self.general = _build_dataclass(GeneralConfig, merged.get("General", {}))
+            self.features = _build_dataclass(FeaturesConfig, merged.get("Features", {}))
+
+    # ------------------------------------------------------------------ #
+    def get(self, section: str, key: str, *, cast: Callable[[Any], Any] | type = str) -> Any:
+        val = self._merged.get(section, {}).get(key)
+        if val is None:
+            return None
+        if isinstance(cast, type):
+            return _cast(val, cast)
+        return cast(val)
+
+    def meta_source(self, section: str, key: str) -> Dict[str, str] | None:
+        return self._sources.get((section, key))
+
+
+# Global singleton
+config_service = ConfigService()
+

--- a/core/config/defaults.ini
+++ b/core/config/defaults.ini
@@ -1,0 +1,16 @@
+[Database]
+qm_tool = databases/qm-tool.db
+logging = databases/logs.db
+
+[Files]
+modules_json = core/config/modules.json
+labels_tsv = core/config/labels.tsv
+
+[General]
+app_name =
+version =
+debug_db_paths = false
+
+[Features]
+enable_document_signer = false
+enable_workflow_manager = false


### PR DESCRIPTION
## Summary
- introduce ConfigService for typed, layered configuration handling
- wrap legacy ConfigLoader around the new service
- add defaults.ini as baseline configuration file

## Testing
- `python -m py_compile core/config/config_service.py core/config/config_loader.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c58712d8b4832bb7d812804bfdbd11